### PR TITLE
Address Dockerfile pulling from latest minimal notebook and building …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM jupyter/minimal-notebook:c54800018c2c
+FROM jupyter/minimal-notebook
 RUN conda install -y -c conda-forge yarn=1.15.2 && conda clean -tipsy
-
-
 
 COPY --chown=jovyan:users yarn.lock package.json ./
 RUN yarn install --frozen-lockfile --ignore-scripts && yarn cache clean
 VOLUME /home/jovyan/node_modules
 
 COPY --chown=jovyan:users . .
-RUN jupyter labextension link --no-build .
+RUN jupyter labextension link .


### PR DESCRIPTION
This PR addresses updates to Dockerfile to build correctly and allow running of container with extension installed. This should allow mybinder to work properly.

Changes include
1. Pulling from latest minimal-notebook image
2. removing --no-build tag on jupyter link, so that it builds inside docker file, not on user request after running the image.

Issues Addressed:
https://github.com/altair-viz/jupyterlab_voyager/issues/66
https://github.com/altair-viz/jupyterlab_voyager/issues/61