### PR TITLE
Address Enabling Export Voyager as Vega Lite File Command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -490,11 +490,11 @@ function activate(
     label: 'Export Voyager as Vega-Lite File',
     caption: 'Export the chart datasource as vl.json file',
     execute: args => {
-      let widget = app.shell.currentWidget;
+      let widget = app.shell.currentWidget as DocumentWidget;
       if (widget) {
-        var datavoyager = (widget as VoyagerPanel | VoyagerPanel_DF)
-          .voyager_cur;
-        var dataSrc = (widget as VoyagerPanel | VoyagerPanel_DF).data_src;
+        const voyager_panel = widget.content as VoyagerPanel | VoyagerPanel_DF
+        var datavoyager = voyager_panel.voyager_cur;
+        var dataSrc = voyager_panel.data_src;
         let context = docManager.contextForWidget(widget) as Context<
           DocumentRegistry.IModel
         >;
@@ -529,8 +529,8 @@ function activate(
       }
     },
     isEnabled: () => {
-      let widget = app.shell.currentWidget;
-      if(widget&&widget.hasClass(Voyager_CLASS)&&(widget as VoyagerPanel|VoyagerPanel_DF).context.path.indexOf('vl.json')===-1){
+      let widget = app.shell.currentWidget as DocumentWidget;
+      if(widget&&widget.content.hasClass(Voyager_CLASS)&&(widget.content as VoyagerPanel|VoyagerPanel_DF).context.path.indexOf('vl.json')===-1){
           return true;
       }
       else{

--- a/src/voyagerpanel.ts
+++ b/src/voyagerpanel.ts
@@ -481,6 +481,19 @@ export class VoyagerPanel extends Widget {
       } else {
         values = read(data, { type: this.fileType });
       }
+      const spec: Object = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+        "data": values['data'],
+        "mark": values['mark'],
+        "encoding": values['encoding'],
+        "height":values['height'],
+        "width":values['width'],
+        "description":values['description'],
+        "name":values['name'],
+        "selection":values['selection'],
+        "title":values['title'],
+        "transform":values['transform']
+      };
       if(this.fileType==='json'||this.fileType==='txt'){
         if(values['data']){
           var DATA = values['data'];
@@ -501,17 +514,7 @@ export class VoyagerPanel extends Widget {
                   { values: local_values }
                 );
               });
-                this.voyager_cur.setSpec({
-                  "mark": values['mark'],
-                  "encoding": values['encoding'],
-                  "height":values['height'],
-                  "width":values['width'],
-                  "description":values['description'],
-                  "name":values['name'],
-                  "selection":values['selection'],
-                  "title":values['title'],
-                  "transform":values['transform']
-              });
+                this.voyager_cur.setSpec(spec);
             } else {
               //web url case: can directly use web url as data source
               this.voyager_cur = CreateVoyager(
@@ -546,17 +549,7 @@ export class VoyagerPanel extends Widget {
           this.data_src = { values };
         }
         //update the specs if possible
-        this.voyager_cur.setSpec({
-            "mark": values['mark'],
-            "encoding": values['encoding'],
-            "height":values['height'],
-            "width":values['width'],
-            "description":values['description'],
-            "name":values['name'],
-            "selection":values['selection'],
-            "title":values['title'],
-            "transform":values['transform']
-        });
+        this.voyager_cur.setSpec(spec);
       } else {
         this.voyager_cur = CreateVoyager(
           this.voyager_widget.node,


### PR DESCRIPTION
This PR enables 'Export Voyager as Vega Lite File' command by

1. Utilizing widget.content to access voyager panel
2. Updating setSpec to use valid spec object

This allows voyager data and spec to be saved and reopened inside vega lite, and Voyager. 
Once a valid vega lite file is opened in Voyager,  various features become available since there are no spec setting errors.

 _Note this does not address saving spec state on reload when using normally .json, .csv, etc -- this should be addressed in another PR_

1. Native jupyterlab saving to the file
2. Re-enable of Bookmark functionality
3. Re-enable of data set functionality(Tested with URL and Upload. Change data set tab does not work as it loads from datavoyager prepackaged datasets which do not exists on the server

<img width="952" alt="export-vega-lite-file-1" src="https://user-images.githubusercontent.com/16566894/57409390-09d0e500-719d-11e9-8528-a7a6a7a46889.PNG">
<img width="946" alt="export-vega-lite-file-2" src="https://user-images.githubusercontent.com/16566894/57409398-0c333f00-719d-11e9-94bb-f7676104ff1f.PNG">
<img width="951" alt="export-vega-lite-file-3" src="https://user-images.githubusercontent.com/16566894/57420895-6f819900-71be-11e9-8cdb-fd01fd0f1c30.PNG">
<img width="982" alt="export-vega-lite-file-4" src="https://user-images.githubusercontent.com/16566894/57420900-73152000-71be-11e9-974a-fe603c18b040.PNG">
<img width="956" alt="export-vega-lite-file-5" src="https://user-images.githubusercontent.com/16566894/57420902-76101080-71be-11e9-9267-3072199d026d.PNG">

